### PR TITLE
fix broken UnitTest.py

### DIFF
--- a/lab_2a_handshake/ClientProtocol.py
+++ b/lab_2a_handshake/ClientProtocol.py
@@ -35,7 +35,7 @@ class ClientProtocol(asyncio.Protocol):
 			self.loop.stop()
 		else:
 			self._callback = callback
-			outBoundPacket = Util.create_outbound_handshake_packet(0, random.randint(0, 2147483646/2), 0)
+			outBoundPacket = Util.create_outbound_packet(0, random.randint(0, 2147483646/2), 0)
 
 			if __name__ =="__main__":
 				print("Client Side: SYN sent: Seq = %d, Ack = %d"%(outBoundPacket.SequenceNumber,outBoundPacket.Acknowledgement))
@@ -58,10 +58,12 @@ class ClientProtocol(asyncio.Protocol):
 
 			 #Do checksum verification first!
 			if (Util.hasValidChecksum(packet) == 0):
-				print("Client side: checksum is bad")
+				if __name__ =="__main__":
+					print("Client side: checksum is bad")
 				self.state = "error_state"
 			else:  # checksum is good, now we look into the packet
-				print("Client side: checksum is good")
+				if __name__ =="__main__":
+					print("Client side: checksum is good")
 				
 				if packet.Type == 1:	# incoming an SYN-ACK handshake packet
 					if self.state != "SYN_ACK_State":
@@ -69,7 +71,7 @@ class ClientProtocol(asyncio.Protocol):
 							print("Client Side: Error: State Error! Expecting SYN_ACK_State but getting %s"%self.state)
 						self.state = "error_state"
 					else:
-						outBoundPacket = Util.create_outbound_handshake_packet(2, packet.Acknowledgement+1, packet.SequenceNumber+1)
+						outBoundPacket = Util.create_outbound_packet(2, packet.Acknowledgement+1, packet.SequenceNumber+1)
 
 						if __name__ =="__main__":
 							print("Client Side: SYN-ACK reveived: Seq = %d, Ack = %d"%(packet.SequenceNumber,packet.Acknowledgement))

--- a/lab_2a_handshake/ServerProtocol.py
+++ b/lab_2a_handshake/ServerProtocol.py
@@ -72,7 +72,7 @@ class ServerProtocol(asyncio.Protocol):
 						if __name__ =="__main__":
 							print("Server Side: ACK reveived: Seq = %d, Ack = %d"%(packet.SequenceNumber,packet.Acknowledgement))
 							print("Server Side: CONNECTION ESTABLISHED!")
-						self.state = "Tramsmission_State"
+						self.state = "Transmission_State"
 
 			if self.transport == None:
 				continue

--- a/lab_2a_handshake/ServerProtocol.py
+++ b/lab_2a_handshake/ServerProtocol.py
@@ -40,10 +40,12 @@ class ServerProtocol(asyncio.Protocol):
 
 			#Do checksum verification first!
 			if (Util.hasValidChecksum(packet) == 0): 
-				print("Server side: checksum is bad")
+				if __name__ =="__main__":
+					print("Server side: checksum is bad")
 				self.state = "error_state"
 			else: # checksum is good, now we look into the packet
-				print("Server side: checksum is good")
+				if __name__ =="__main__":
+					print("Server side: checksum is good")
 				
 				if packet.Type == 0:	# incoming an SYN handshake packet
 					if self.state != "SYN_ACK_State":
@@ -51,7 +53,7 @@ class ServerProtocol(asyncio.Protocol):
 							print("Server Side: Error: State Error! Expecting SYN_ACK_State but getting %s"%self.state)
 						self.state = "error_state"
 					else:
-						outBoundPacket = Util.create_outbound_handshake_packet(1, random.randint(0, 2147483646/2), packet.SequenceNumber+1)
+						outBoundPacket = Util.create_outbound_packet(1, random.randint(0, 2147483646/2), packet.SequenceNumber+1)
 
 						if __name__ =="__main__":
 							print("Server Side: SYN reveived: Seq = %d, Ack = %d"%(packet.SequenceNumber,packet.Acknowledgement))

--- a/lab_2a_handshake/UnitTest.py
+++ b/lab_2a_handshake/UnitTest.py
@@ -2,6 +2,7 @@ from playground.network.packet import PacketType
 from playground.network.packet.fieldtypes import UINT32, UINT16, UINT8, STRING, BUFFER, BOOL
 from playground.network.packet.fieldtypes.attributes import *
 from PEEPPacket import *
+from Util import *
 from ServerProtocol import ServerProtocol
 from ClientProtocol import ClientProtocol
 from playground.asyncio_lib.testing import TestLoopEx
@@ -9,39 +10,35 @@ from playground.network.testing import MockTransportToStorageStream as MockTrans
 from playground.network.testing import MockTransportToProtocol
 
 import asyncio
+def basicUnitTestForUtil():
+
+	# test for create_outbound_packet()
+	packet1 = Util.create_outbound_packet(1, 2, 3, b"data")
+	assert packet1.Type == 1
+	assert packet1.SequenceNumber == 2
+	assert packet1.Acknowledgement == 3
+	assert packet1.Data == b"data"
+	print ("- test for Util.create_outbound_packet() SUCCESS")	
+
+
+
 
 def basicUnitTestForPEEPPacketPacket():
 
 	# test for PEEPPacket Serialize Deserialize
-	packet1 = PEEPPacket()
-	packet1.Type = 1
-	packet1.SequenceNumber = 1
-	packet1.Checksum = 1
-	packet1.Acknowledgement = 1
-	packet1.Data = b"data"
+	packet1 = Util.create_outbound_packet(1, 1, 1, b"data")
 	packet1Bytes = packet1.__serialize__()
 	packet1_serialized_deserialized = PEEPPacket.Deserialize(packet1Bytes)
 	assert packet1 == packet1_serialized_deserialized
 	print ("- test for PEEPPacket Serialize Deserialize SUCCESS")
 
 
-
 	# negative test for PEEPPacket Serialize Deserialize
-	packet1 = PEEPPacket()
-	packet1.Type = 1
-	packet1.SequenceNumber = 1
-	packet1.Checksum = 1
-	packet1.Acknowledgement = 1
-	packet1.Data = b"data"
+	packet1 = Util.create_outbound_packet(1, 1, 1, b"data")
 	packet1Bytes = packet1.__serialize__()
 	packet1_serialized_deserialized = PEEPPacket.Deserialize(packet1Bytes)
 
-	packet2 = PEEPPacket()
-	packet2.Type = 1
-	packet2.SequenceNumber = 1
-	packet2.Checksum = 999
-	packet2.Acknowledgement = 1
-	packet2.Data = b"data"
+	packet2 = Util.create_outbound_packet(1, 2, 1, b"datadata")
 	packet2Bytes = packet2.__serialize__()
 	packet2_serialized_deserialized = PEEPPacket.Deserialize(packet2Bytes)
 	assert packet1_serialized_deserialized != packet2_serialized_deserialized
@@ -50,10 +47,7 @@ def basicUnitTestForPEEPPacketPacket():
 
 
 	# test for PEEPPacket Optional fields
-	packet1 = PEEPPacket()
-	packet1.Type = 1
-	packet1.Checksum = 1
-	packet1.Data = b"data"
+	packet1 = Util.create_outbound_packet(1, 2, 3)
 	packet1Bytes = packet1.__serialize__()
 	packet1_serialized_deserialized = PEEPPacket.Deserialize(packet1Bytes)
 	assert packet1 == packet1_serialized_deserialized
@@ -83,17 +77,11 @@ def basicUnitTestForProtocol():
 	client.connection_made(cTransport)
 	server.connection_made(sTransport)
 
-	MockPEEPPacket_SYN = PEEPPacket()
-	MockPEEPPacket_SYN.Type = 0
-	MockPEEPPacket_SYN.SequenceNumber = 1
-	MockPEEPPacket_SYN.Checksum = 1
-	MockPEEPPacket_SYN.Acknowledgement = 1
-	MockPEEPPacket_SYN.Data = b"data"
+	MockPEEPPacket_SYN = Util.create_outbound_packet(0, 1, 1, b"data")
 	packetBytes = MockPEEPPacket_SYN.__serialize__()
 	server.state = "SYN_State"
 	client.state = "SYN_ACK_State"
 	server.data_received(packetBytes)
-	print(server.state)
 	assert server.state == "error_state"
 	print("- negative test for messing up packet order SUCCESS")
 	print ("")
@@ -103,12 +91,7 @@ def basicUnitTestForProtocol():
 	client.connection_made(cTransport)
 	server.connection_made(sTransport)
 
-	MockPEEPPacket_ACK = PEEPPacket()
-	MockPEEPPacket_ACK.Type = 2
-	MockPEEPPacket_ACK.SequenceNumber = 1
-	MockPEEPPacket_ACK.Checksum = 1
-	MockPEEPPacket_ACK.Acknowledgement = 1
-	MockPEEPPacket_ACK.Data = b"data"
+	MockPEEPPacket_ACK = Util.create_outbound_packet(2, 1, 1, b"data")
 	packetBytes = MockPEEPPacket_ACK.__serialize__()
 	server.state = "SYN_State"
 	client.state = "Transmission_State"
@@ -119,6 +102,15 @@ def basicUnitTestForProtocol():
 
 
 if __name__ =="__main__":
+	print ("=======================================")
+	print ("### START BASIC UNIT TEST FOR Util###")
+	print ("")
+	basicUnitTestForUtil()
+	print("")
+	print("")
+	print("### ALL UTIL UNIT TEST SUCCESS! ###")
+	print("=====================================")
+
 	print ("=======================================")
 	print ("### START BASIC UNIT TEST FOR PEEPPacket PACKET###")
 	print ("")

--- a/lab_2a_handshake/UnitTest.py
+++ b/lab_2a_handshake/UnitTest.py
@@ -96,7 +96,8 @@ def basicUnitTestForProtocol():
 	server.state = "SYN_State"
 	client.state = "Transmission_State"
 	server.data_received(packetBytes)
-	assert server.state == "Tramsmission_State"
+	assert server.state == "Transmission_State"
+	assert client.state == "Transmission_State"
 	print("- test for client vericifation result SUCCESS")
 	print ("")
 

--- a/lab_2a_handshake/Util.py
+++ b/lab_2a_handshake/Util.py
@@ -4,12 +4,12 @@ from PEEPPacket import *
 
 class Util():
 	@staticmethod
-	def create_outbound_handshake_packet(Type, seqNum=None, ackNum=None, data=None):
+	def create_outbound_packet(Type, seqNum=None, ackNum=None, data=None):
 		outBoundPacket = PEEPPacket()
 		outBoundPacket.Type = Type
 		if seqNum != None: outBoundPacket.SequenceNumber = seqNum
 		if ackNum != None: outBoundPacket.Acknowledgement = ackNum
-
+		if data != None: outBoundPacket.Data = data
 		checksum_bytes = Util.prepare_checksum_bytes(Type=outBoundPacket.Type, seqNum=outBoundPacket.SequenceNumber, ackNum=outBoundPacket.Acknowledgement, data=outBoundPacket.Data)
 		checksum = Util.checksum(checksum_bytes)
 		outBoundPacket.Checksum = checksum


### PR DESCRIPTION
Content in this PR:
1. Fixed UnitTest.py
2. Rename create_outbound_handshake_packet() into create_outbound_packet()
3. Set the Data field in create_outbound_packet() (We missed setting up this field before)

Test Plan:
1. ran "python ServerProtocol.py" and "python ClientProtocol.py" successful (three-way handshake succeed and connection established)
2. ran "python UnitTest.py" successful

**## Important**
**From now on, you should run "python UnitTest.py" after your make any local change so that you can make sure that your current change doesn't break our previous feature! Please do that!!!! And we will keep adding UnitTest after every time we implement our new feature** 
@sbw111 @JMKJR @ehsia1 @lysept 