### PR TITLE
Remove ACK from SYN packet

### DIFF
--- a/lab_2a_handshake/ClientProtocol.py
+++ b/lab_2a_handshake/ClientProtocol.py
@@ -35,10 +35,9 @@ class ClientProtocol(asyncio.Protocol):
 			self.loop.stop()
 		else:
 			self._callback = callback
-			outBoundPacket = Util.create_outbound_packet(0, random.randint(0, 2147483646/2), 0)
-
+			outBoundPacket = Util.create_outbound_packet(0, random.randint(0, 2147483646/2))
 			if __name__ =="__main__":
-				print("Client Side: SYN sent: Seq = %d, Ack = %d"%(outBoundPacket.SequenceNumber,outBoundPacket.Acknowledgement))
+				print("Client Side: SYN sent: Seq = %d"%(outBoundPacket.SequenceNumber))
 			packetBytes = outBoundPacket.__serialize__()
 			self.state = "SYN_ACK_State_1"
 			self.transport.write(packetBytes)

--- a/lab_2a_handshake/ServerProtocol.py
+++ b/lab_2a_handshake/ServerProtocol.py
@@ -56,7 +56,7 @@ class ServerProtocol(asyncio.Protocol):
 						outBoundPacket = Util.create_outbound_packet(1, random.randint(0, 2147483646/2), packet.SequenceNumber+1)
 
 						if __name__ =="__main__":
-							print("Server Side: SYN reveived: Seq = %d, Ack = %d"%(packet.SequenceNumber,packet.Acknowledgement))
+							print("Server Side: SYN reveived: Seq = %d"%(packet.SequenceNumber))
 							print("Server Side: SYN-ACK sent: Seq = %d, Ack = %d"%(outBoundPacket.SequenceNumber, outBoundPacket.Acknowledgement))
 						packetBytes = outBoundPacket.__serialize__()
 						self.state = "SYN_State_1"


### PR DESCRIPTION
SYN packet is not supposed to have an ACK field (this is an optional field). So I remove this field from SYN packet.