### PR TITLE
Turn off the logging for protocol in UnitTest.py

### DIFF
--- a/lab_2a_handshake/UnitTest.py
+++ b/lab_2a_handshake/UnitTest.py
@@ -66,8 +66,8 @@ def basicUnitTestForPEEPProtocol(loggingFlag):
 	asyncio.set_event_loop(TestLoopEx())
 	loop = asyncio.get_event_loop()
 
-	server = ServerProtocol(loop)
-	client = ClientProtocol(loop)
+	server = ServerProtocol(loop, False)
+	client = ClientProtocol(loop, False)
 
 	client.set_timeout_flag(False)
 	cTransport, sTransport = MockTransportToProtocol.CreateTransportPair(client, server)
@@ -239,8 +239,8 @@ def basicUnitTestForAppLayerProtocol(loggingFlag):
 	asyncio.set_event_loop(TestLoopEx())
 	loop = asyncio.get_event_loop()
 
-	server = VerificationCodeServerProtocol(loop)
-	client = VerificationCodeClientProtocol(1, loop)
+	server = VerificationCodeServerProtocol(loop, False)
+	client = VerificationCodeClientProtocol(1, loop, False)
 	cTransport, sTransport = MockTransportToProtocol.CreateTransportPair(client, server)
 
 	# test for general connection_made 

--- a/lab_2a_handshake/VerificationCodeClientProtocol.py
+++ b/lab_2a_handshake/VerificationCodeClientProtocol.py
@@ -30,8 +30,8 @@ class VerificationCodeClientProtocol(asyncio.Protocol):
 
 	def send_request_packet(self, callback=None):
 		#print("Client: %s"%self.state)
-		if self.logging:
-			if __name__ =="__main__":
+		if self.state != "initial_state":
+			if self.logging:
 				print("App_Layer Client Side: Error: State Error! Expecting initial_state but getting %s"%self.state)
 			self.state = "error_state"
 			self.transport.close()


### PR DESCRIPTION
**## What I did:**
1. Fixed the bug introduced in #12 in VerificationCodeClientProtocol.py (I didn't realize it when review #12 )
2. Previously, UnitTest.py will print not only the UnitTest result, but also Protocol logging (something like: xxx connection made, which we only want to see in real situation but not in UnitTest), So I use the logging switch implemented in #12 and turn off these protocol logging in UnitTest.py

**## Test Plan:**
1. Ran main program successfully (VerificationCodeServerProtocol,.py VerificationCodeClientProtocol.py)

2. Ran UnitTest.py successfully and its logging are ideally what I want (looks clean and simple)