### PR TITLE
update our connector according to the update in playground

### DIFF
--- a/lab_2a_handshake/ClientProtocol.py
+++ b/lab_2a_handshake/ClientProtocol.py
@@ -15,10 +15,9 @@ class ClientProtocol(StackingProtocol):
 	TIMEOUTLIMIT = 10
 	timeout_flag = True
 
-	def __init__(self, loop, logging=True):
+	def __init__(self, logging=True):
 		if logging:
 			print("PEEP Client Side: Init Compelete...")
-		self.loop = loop
 		self._deserializer = PacketType.Deserializer()
 		super().__init__
 		self.transport = None
@@ -37,7 +36,6 @@ class ClientProtocol(StackingProtocol):
 				print("PEEP Client Side: Time-out. Close Connection.")
 			self.state = "error_state"
 			self.transport.close()
-			self.loop.stop()
 
 	def set_timeout_flag(self, flag): #Only used in UnitTest to turn off timeout_flag
 		self.timeout_flag = flag
@@ -51,7 +49,6 @@ class ClientProtocol(StackingProtocol):
 				print("PEEP Client Side: Error: State Error! Expecting Initial_SYN_State but getting %s"%self.state)
 			self.state = "error_state"
 			self.transport.close()
-			self.loop.stop()
 		else:
 			self._callback = callback
 			outBoundPacket = Util.create_outbound_packet(0, random.randint(0, 2147483646/2))
@@ -69,7 +66,6 @@ class ClientProtocol(StackingProtocol):
 		self.transport = None
 		if self.logging:
 			print("PEEP Client Side: Connection Lost...")
-		self.loop.stop()
 
 	def data_received(self, data):
 		self._deserializer.update(data)
@@ -116,7 +112,6 @@ class ClientProtocol(StackingProtocol):
 				continue
 			if self.state == "error_state":
 				self.transport.close()
-				self.loop.stop()
 
 
 

--- a/lab_2a_handshake/ServerProtocol.py
+++ b/lab_2a_handshake/ServerProtocol.py
@@ -12,10 +12,9 @@ import asyncio
 
 class ServerProtocol(StackingProtocol):
 	state = "SYN_ACK_State_0"
-	def __init__(self, loop, logging=True):
+	def __init__(self, logging=True):
 		if logging:
 			print("PEEP Server Side: Init Compelete...")
-		self.loop = loop
 		self._deserializer = PacketType.Deserializer()
 		super().__init__
 		self.transport = None
@@ -31,7 +30,6 @@ class ServerProtocol(StackingProtocol):
 		self.transport = None
 		if self.logging:
 			print("PEEP Server Side: Connection Lost...")
-		self.loop.stop()
 
 	def data_received(self, data):
 		self._deserializer.update(data)
@@ -83,7 +81,6 @@ class ServerProtocol(StackingProtocol):
 				continue
 			if self.state == "error_state":
 				self.transport.close()
-				self.loop.stop()
 
 
 

--- a/lab_2a_handshake/VerificationCodeClientProtocol.py
+++ b/lab_2a_handshake/VerificationCodeClientProtocol.py
@@ -148,14 +148,16 @@ if __name__ =="__main__":
 	loop = asyncio.get_event_loop()
 	loop.set_debug(enabled = True)
 
-	f = StackingProtocolFactory(lambda: PassThroughProtocol1(), lambda: ClientProtocol(loop))
-	# f = StackingProtocolFactory(lambda: ClientProtocol(loop), lambda: PassThroughProtocol1())
-	ptConnector = playground.Connector(protocolStack=f)
-	playground.setConnector("passthroughClient", ptConnector)
+	####### this part should be put into __init__.py ############
+	cf = StackingProtocolFactory(lambda: PassThroughProtocol1(), lambda: ClientProtocol())
+	sf = StackingProtocolFactory(lambda: PassThroughProtocol1(), lambda: ServerProtocol())
+	lab2Connector = playground.Connector(protocolStack=(cf, sf))
+	playground.setConnector("lab2_protocol", lab2Connector)
+	#############################################################
+
 	print("----- NEW CONNECTOR SETUP on Client Side-----")
 
-	#coro = loop.create_connection(lambda: VerificationCodeClientProtocol(1, loop), host="127.0.0.1", port=8000)
-	coro = playground.getConnector('passthroughClient').create_playground_connection(lambda: VerificationCodeClientProtocol(1, loop), "20174.1.1.1", 101)
+	coro = playground.getConnector('lab2_protocol').create_playground_connection(lambda: VerificationCodeClientProtocol(1, loop), "20174.1.1.1", 101)
 	transport, protocol = loop.run_until_complete(coro)
 	protocol.send_request_packet(protocol.callbackForUserVCInput)
 	# protocol.send_request_packet()

--- a/lab_2a_handshake/VerificationCodeServerProtocol.py
+++ b/lab_2a_handshake/VerificationCodeServerProtocol.py
@@ -131,19 +131,20 @@ class VerificationCodeServerProtocol(asyncio.Protocol):
 
 
 if __name__ =="__main__":
-	# f = StackingProtocolFactory(lambda: PassThroughServerProtocol(), lambda: PassThroughClientProtocol())
-	# ptConnector = playground.Connector(protocolStack=f)
-	# playground.setConnector("passthrough", ptConnector)
+	
 	loop = asyncio.get_event_loop()
 	loop.set_debug(enabled = True)
 
-	f = StackingProtocolFactory(lambda: PassThroughProtocol1(), lambda: ServerProtocol(loop))
-	# f = StackingProtocolFactory(lambda: ServerProtocol(loop), lambda: PassThroughProtocol1())
-	ptConnector = playground.Connector(protocolStack=f)
-	playground.setConnector("passthroughServer", ptConnector)
+	####### this part should be put into __init__.py ############
+	cf = StackingProtocolFactory(lambda: PassThroughProtocol1(), lambda: ClientProtocol())
+	sf = StackingProtocolFactory(lambda: PassThroughProtocol1(), lambda: ServerProtocol())
+	lab2Connector = playground.Connector(protocolStack=(cf, sf))
+	playground.setConnector("lab2_protocol", lab2Connector)
+	#############################################################
+
 	print("----- NEW CONNECTOR SETUP on Serve Side-----")
 
-	coro = playground.getConnector('passthroughServer').create_playground_server(lambda: VerificationCodeServerProtocol(loop), 101)
+	coro = playground.getConnector('lab2_protocol').create_playground_server(lambda: VerificationCodeServerProtocol(loop), 101)
 
 	server = loop.run_until_complete(coro)
 	try:


### PR DESCRIPTION
**## What @sbw111 and I did:**
1. change the connector in playground according to the recent update in playground. (in main function in VCServerProtocol and VCClientProtocol)

2. delete the loop parameter in PEEP Protocol.

**## Test Plan:**
1. Ran "python VerificationCodeServerProtocol.py" and "python VerificationCodeClientProtocol.py" successfully.

2. Ran "Python UnitTest.py" successfully

**## What to do next:**
put the connector setup code into __init.py__ according to the submission instruction.